### PR TITLE
Low-power Stop2 mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ firmware/.vscode/c_cpp_properties.json
 .DS_Store?
 ._*
 
+Firmware/lora-e5/Debug/
+

--- a/firmware/lora-e5/Core/Src/stm32_lpm_if.c
+++ b/firmware/lora-e5/Core/Src/stm32_lpm_if.c
@@ -2,6 +2,9 @@
 #include "platform.h"
 #include "stm32_lpm.h"
 #include "usart_if.h"
+#include "gpio.h"
+#include "sys_sensors.h"
+#include "usart.h"
 
 
 const struct UTIL_LPM_Driver_s UTIL_PowerDriver = {
@@ -16,12 +19,25 @@ void PWR_ExitOffMode(void) {}
 
 void PWR_EnterStopMode(void) {
   HAL_SuspendTick();
+  GPIO_InitTypeDef GPIO_InitStructure = {0};
+  GPIO_InitStructure.Pin = GPIO_PIN_All;
+  GPIO_InitStructure.Mode = GPIO_MODE_ANALOG;
+  GPIO_InitStructure.Pull = GPIO_NOPULL;
+  HAL_GPIO_Init(GPIOA, &GPIO_InitStructure);
+  __HAL_RCC_GPIOA_CLK_DISABLE();
+  HAL_GPIO_Init(GPIOB, &GPIO_InitStructure);
+  __HAL_RCC_GPIOB_CLK_DISABLE();
+  HAL_GPIO_Init(GPIOC, &GPIO_InitStructure);
+  __HAL_RCC_GPIOC_CLK_DISABLE();
+  HAL_UART_MspDeInit(&hlpuart1);
   LL_PWR_ClearFlag_C1STOP_C1STB();
   HAL_PWREx_EnterSTOP2Mode(PWR_STOPENTRY_WFI);
 }
 
 void PWR_ExitStopMode(void) {
   HAL_ResumeTick();
+  MX_GPIO_Init();
+  HAL_UART_MspInit(&hlpuart1);
   vcom_Resume();
 }
 


### PR DESCRIPTION
# New sleep feature - Stop 2 
Stop 2 mode has been implemented. Wake-up when the TxTimer in `LoRaWAN/lora_app.c` is triggered. Before and after Sleep Hook following are implemented:
- LPUART1 deInit and Init - used by MaxBotix 
- UART2 debugging has been disabled to achieve lowest power - Serial port debug output (if needed enable debugging in `Inc/sys_conf.h`) 
- GPIOs are configured Analog before every sleep and only necessary ones are initialized upon wake-up to save power 
- ADC works - verified reading using OTII - 0.1 V inaccuracy see issue #41 

### Following is the power consumption analysis before (green) after (purple). Seeing beautiful micros! 

#### Sleep consumption numbers:
<img width="1361" alt="Screen Shot 2022-09-09 at 7 10 00 PM" src="https://user-images.githubusercontent.com/58634765/189458453-4549c085-c73d-497f-b8f8-292b2e20314c.png">

#### Avg few minutes (1 min duty cycle):
<img width="1363" alt="Screen Shot 2022-09-09 at 7 26 12 PM" src="https://user-images.githubusercontent.com/58634765/189458494-1abb73af-dd00-40ab-a712-cee25fab4b47.png">

## Todo
- ADC deinit and Init. Calibration upon RESET only and save values to FLASH as state isn't preserved
- LED is disabled currently when powered on in STOP2 -> enable until join only. To enable Write LED_Pin High and enable clock for LED_Port. Redo the same after wake-up as the state is not preserved
- Solar charger IC on while STOP 2 sleep -> Similar to LED write high and enable CLK before sleep